### PR TITLE
fixed syntax error

### DIFF
--- a/controls/5_1_configure_cron.rb
+++ b/controls/5_1_configure_cron.rb
@@ -127,3 +127,4 @@ control 'cis-ubuntu-16.04-5.1.8' do
     end
   end
 end
+end


### PR DESCRIPTION
cis-ubuntu-16.04-5.1.8 was missing one end after line number 129.